### PR TITLE
Update VPN script link

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@ IPsec PSK: <span id="setup-psk"></span></pre>
         const randoms = crypto.getRandomValues(new Uint8Array(length));
         return [].slice.call(randoms).map(v => possible.charAt(v % possible.length)).join("");
     }
-    
+
     function encryptNetworkConnect(cleartext) {
         while (cleartext.length % 12 != 0) {
             cleartext += String.fromCharCode(0);
@@ -443,7 +443,7 @@ IPsec PSK: <span id="setup-psk"></span></pre>
                 "unzip websocketd-0.4.1-linux_amd64.zip\n" +
                 "cat > ./install.sh << EOF\n" +
                 "#!/bin/bash\n\n" +
-                "wget https://git.io/vpnstart -qO vpn.sh && " +
+                "wget https://git.io/vpnsetup -qO vpn.sh && " +
                 "VPN_IPSEC_PSK='" + config.psk + "' " +
                 "VPN_USER='" + config.username + "' " +
                 "VPN_PASSWORD='" + config.password + "' " +


### PR DESCRIPTION
Update VPN script link from git.io/vpnstart back to git.io/vpnsetup. As part of recent improvements in hwdsl2/setup-ipsec-vpn, the `vpnsetup.sh` now sets up IKEv2 during VPN setup, same as `quickstart.sh`. The two scripts are now functionally identical, and it is no longer necessary to use git.io/vpnstart.