### PR TITLE
Update VPN script link due to git.io deprecation

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@ IPsec PSK: <span id="setup-psk"></span></pre>
                 "unzip websocketd-0.4.1-linux_amd64.zip\n" +
                 "cat > ./install.sh << EOF\n" +
                 "#!/bin/bash\n\n" +
-                "wget https://git.io/vpnsetup -qO vpn.sh && " +
+                "wget https://github.com/hwdsl2/setup-ipsec-vpn/raw/master/vpnsetup.sh -qO vpn.sh && " +
                 "VPN_IPSEC_PSK='" + config.psk + "' " +
                 "VPN_USER='" + config.username + "' " +
                 "VPN_PASSWORD='" + config.password + "' " +


### PR DESCRIPTION
Update the VPN script link to a direct URL. git.io is deprecated, see: https://github.blog/changelog/2022-04-25-git-io-deprecation/